### PR TITLE
Slugification plugin

### DIFF
--- a/lib/basicAuth.js
+++ b/lib/basicAuth.js
@@ -11,6 +11,7 @@ module.exports = function(schema, options) {
 
   var loginPath = (options.loginPath || 'username')
     , hashPath = (options.hashPath || 'hash')
+    , workFactor = (options.workFactor || 10)
     , query = {}
     , fields = {}
 
@@ -40,7 +41,7 @@ module.exports = function(schema, options) {
   schema
     .method('setPassword', function(password, next) {
       var self = this
-      bcrypt.gen_salt(10, function(err, salt) {
+      bcrypt.gen_salt(workFactor, function(err, salt) {
         if (err) return next(err)
         bcrypt.encrypt(password, salt, function(err, hash) {
           if (err) return next(err)

--- a/lib/slugify.js
+++ b/lib/slugify.js
@@ -1,0 +1,48 @@
+
+module.exports = function(schema, options) {
+  options || (options = {})
+
+  var target = options.target || 'slug'       // Slug destination
+    , source = options.source || 'title'      // Slug content field
+    , maxLength = options.length || 50        // Max slug length
+    , spaceChar = options.spaceChar || '-'    // Space replacement
+    , invalidChar = options.invalidChar || '' // Invalid char replacement
+    , override = options.override || false    // Override slug on set
+    , fr = 'àáâãäåçèéêëìíîïñðóòôõöøùúûüýÿ'    // Accent chars to find
+    , to = 'aaaaaaceeeeiiiinooooooouuuuyy'    // Accent replacement
+    , fields = {}
+  
+  if (!schema.paths[target]) {
+    fields[target] = {
+      type: String 
+    , unique: true
+    , sparse: true
+    }
+    schema.add(fields)
+  }
+  
+  schema
+    .path(target)
+    .set(function(str) {
+      str = str
+        .replace(/^\s+|\s+$/g, '')
+        .toLowerCase()
+      
+      for (var i=0; i<fr.length; i++) {
+        str = str.replace(new RegExp(fr.charAt(i), 'g'), to.charAt(i))
+      }
+
+      return str
+        .replace(/[^a-z0-9 -]/g, invalidChar)
+        .replace(new RegExp('['+invalidChar+']'+'+', 'g'), invalidChar)
+        .replace(/\s+/g, spaceChar)
+        .substr(0, maxLength)
+    })
+  
+  schema
+    .path(source)
+    .set(function(v) {
+      if (!this[target] || override) this[target] = v
+      return v
+    })
+}


### PR DESCRIPTION
Converts source path into a url friendly slug.

Example with default options:

schema.plugin(troop.slugify, {
  target: 'slug'  // Slug destination
, source: 'name'  // Slug content field
, maxLength: 50   // Max slug length
, spaceChar: '-'  // Space replacement
, invalidChar: '' // Invalid char replacement
, override: false // Override slug on set
})
