### PR TITLE
Issue 19 - pagination module working with Mongoose 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ FooModel.paginate({
   page: 2
 , query: { count: { $gt: 25 } }
 , limit: 25
-, fields: ['name']
+, fields: 'field1, field2'
 }, function(err, docs, count, pages, current) {
   
   // docs.length = 5

--- a/lib/pagination.js
+++ b/lib/pagination.js
@@ -14,7 +14,7 @@ function pagination (schema, options) {
   // Options
   var defaultLimit = options.defaultLimit || 10
     , defaultQuery = options.defaultQuery || {}
-    , defaultFields = options.defaultFields || []
+    , defaultFields = options.defaultFields || {}
     , remember = options.remember || false
     , defaultPage = 1
     , currentLimit = defaultLimit


### PR DESCRIPTION
Changed default fields argument to be an object instead of an array since Mongoose 3 only accepts strings or objects as arguments to query selects.

Also changed README.md pagination example to use a string for field argument instead of an array.

Updated: Submitted pull request with changes.
