### PR TITLE
use specified field for acl info

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -22,25 +22,25 @@ function acl (schema, options) {
     }
   }
   schema.add(fields)
-  
+
   schema.method('addAccess', function (key) {
     if (!this.access(key)) {
-      this.acl.push(key)
-      this.markModified('acl')
+      this[aclPath].push(key)
+      this.markModified(aclPath)
     }
     return this
   })
-  
+
   schema.method('removeAccess', function (key) {
     if (this.access(key)) {
-      this.acl.splice(this.acl.indexOf(key), 1) 
-      this.markModified('acl')
+      this[aclPath].splice(this[aclPath].indexOf(key), 1)
+      this.markModified(aclPath)
     }
     return this
   })
 
   schema.method('access', function (key, next) {
-    var bool = !!~this.acl.indexOf(key)
+    var bool = !!~this[aclPath].indexOf(key)
     next && next(bool)
     return bool
   })


### PR DESCRIPTION
When you specify a field to use for ACL that isn't `acl`, the current code doesn't work. This is a fix for that.
