### PR TITLE
bumped `directory` dependency to ~0.1.0 for better Windows compatibility...

### DIFF
--- a/lib/keywords/aggressive_tokenizer.js
+++ b/lib/keywords/aggressive_tokenizer.js
@@ -23,8 +23,8 @@ THE SOFTWARE.
 var Tokenizer = require('./tokenizer'),
     sys = require('util');
 
-AggressiveTokenizer = function() {
-    Tokenizer.call(this);    
+var AggressiveTokenizer = function() {
+    Tokenizer.call(this);
 };
 sys.inherits(AggressiveTokenizer, Tokenizer);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "mongoose-troop",
-  "version" : "0.0.8",
+  "version" : "0.0.9",
   "description" : "a collection of plugins for mongoose",
   "main" : "index.js",
   "bin" : {},

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "redis": ">= 0.7.1"
   },
   "dependencies" : {
-    "directory": "0.0.x", 
+    "directory": "~0.1.0", 
     "mongoose": "~3.5.8"
   },
   "devDependencies" : {


### PR DESCRIPTION
We're having issues on Windows with the `directory` npm module that this module depends on.

In the mean time, the `directory` module has been updated for better Windows support and it doesn't depend on the `findit` npm module either (it also has issues on Windows).

This pull request bumps the `directory` dependency to ~0.1.0. All the tests continue to pass and it works for us on Windows.

Would be great if you could accept the pull request and publish a new version to NPM. Note that I did not change the module's version.
